### PR TITLE
Remove unnecessary readme field from Cargo.toml

### DIFF
--- a/renderdoc-sys/Cargo.toml
+++ b/renderdoc-sys/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT OR Apache-2.0"
 homepage = "https://github.com/ebkalderon/renderdoc-rs"
 repository = "https://github.com/ebkalderon/renderdoc-rs"
 documentation = "https://docs.rs/renderdoc-sys/"
-readme = "README.md"
 keywords = ["ffi", "renderdoc"]
 
 [dependencies]


### PR DESCRIPTION
### Fixed

* Remove unused `readme` field so crate can build.