### PR TITLE
Remove publish = false from renderdoc-derive Cargo.toml

### DIFF
--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/ebkalderon/renderdoc-rs"
 repository = "https://github.com/ebkalderon/renderdoc-rs"
-publish = false
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
### Fixed

* Remove `publish = false` from `renderdoc-derive` so `renderdoc` can be published.