### PR TITLE
Add comments, prepare renderdoc-derive for publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.4.0] - 2018-09-16
 ### Added
 * Create `renderdoc-sys` crate for raw FFI bindings.
+* Create `renderdoc-derive` crate for internal codegen.
 * Add support for RenderDoc API 1.1.1, 1.1.2, and 1.2.0.
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/ebkalderon/renderdoc-rs"
 repository = "https://github.com/ebkalderon/renderdoc-rs"
 documentation = "https://docs.rs/renderdoc/"
 readme = "README.md"
+categories = ["rendering"]
 keywords = ["graphics", "profile", "renderdoc", "trace"]
 
 [features]

--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -2,9 +2,13 @@
 name = "renderdoc-derive"
 version = "0.1.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
+description = "Internal custom derive macro intended for renderdoc-rs"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/ebkalderon/renderdoc-rs"
 repository = "https://github.com/ebkalderon/renderdoc-rs"
+documentation = "https://docs.rs/renderdoc-derive/"
+categories = ["development-tools::build-utils"]
+keywords = ["derive", "renderdoc"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
### Added

* Add categories and doc comments.

### Fixed

* Prepare `renderdoc-derive` for publish so `renderdoc` can be published.