### PR TITLE
Set renderdoc-derive version to 0.4.0 to match other crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["glutin"]
 [dependencies]
 bitflags = "1.0"
 lazy_static = "1.0"
-renderdoc-derive = { version = "0.1.0", path = "./renderdoc-derive" }
+renderdoc-derive = { version = "0.4.0", path = "./renderdoc-derive" }
 renderdoc-sys = { version = "0.4.0", path = "./renderdoc-sys" }
 libloading = "0.5.0"
 

--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc-derive"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal custom derive macro intended for renderdoc-rs"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Fixed

* Set `renderdoc-derive` version to 0.4.0 to match other crates.