### PR TITLE
Fix typo in RenderDocV111 trait

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -302,7 +302,7 @@ pub trait RenderDocV111: RenderDocV110 {
     fn is_target_control_connected(&self) -> bool {
         unsafe {
             (self
-                .entry_v112()
+                .entry_v111()
                 .__bindgen_anon_3
                 .IsTargetControlConnected
                 .unwrap())()


### PR DESCRIPTION
### Fixed

* Fix typo in method name in `RenderDocV111` trait so the crate builds.