### PR TITLE
Add nightly to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,18 +20,19 @@ jobs:
       - run:
           name: Nightly Build
           command: |
+            rustup toolchain add nightly
             rustup run nightly rustc --version --verbose
             rustup run nightly cargo --version --verbose
             rustup run nightly cargo build
       - run:
           name: Stable Build
           command: |
-            rustup run stable rustc --version --verbose
-            rustup run stable cargo --version --verbose
-            rustup run stable cargo build
+            rustc --version --verbose
+            cargo --version --verbose
+            cargo build
       - run:
           name: Test
-          command: rustup run stable cargo test --no-run
+          command: cargo test --no-run
       - save_cache:
           key: project-cache
           paths:


### PR DESCRIPTION
### Changed

* Tentatively add nightly Rust in CI.

### Fixed

* Update stable commands so they aren't called through `rustup`.