### PR TITLE
Add CI and documentation badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 categories = ["rendering"]
 keywords = ["graphics", "profile", "renderdoc", "trace"]
 
+[badges]
+circle-ci = { repository = "ebkalderon/renderdoc-rs" }
+
 [features]
 default = ["glutin"]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # renderdoc-rs
 
+[![Build Status][s1]][cc] [![Crates.io][s2]][ci] [![Documentation][s3]][docs]
+
+[s1]: https://circleci.com/gh/ebkalderon/renderdoc-rs.svg?style=shield
+[cc]: https://circleci.com/gh/ebkalderon/renderdoc-rs
+[s2]: https://img.shields.io/crates/v/renderdoc.svg
+[ci]: https://crates.io/crates/renderdoc
+[s3]: https://img.shields.io/badge/docs-master-blue.svg
+[docs]: https://docs.rs/renderdoc
+
 Rust bindings to [RenderDoc], a popular graphics debugger.
 
 [RenderDoc]: https://renderdoc.org/

--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -10,6 +10,9 @@ documentation = "https://docs.rs/renderdoc-derive/"
 categories = ["development-tools::build-utils"]
 keywords = ["derive", "renderdoc"]
 
+[badges]
+circle-ci = { repository = "ebkalderon/renderdoc-rs" }
+
 [lib]
 proc-macro = true
 

--- a/renderdoc-sys/Cargo.toml
+++ b/renderdoc-sys/Cargo.toml
@@ -9,4 +9,7 @@ repository = "https://github.com/ebkalderon/renderdoc-rs"
 documentation = "https://docs.rs/renderdoc-sys/"
 keywords = ["ffi", "renderdoc"]
 
+[badges]
+circle-ci = { repository = "ebkalderon/renderdoc-rs" }
+
 [dependencies]


### PR DESCRIPTION
### Changed

* Add CI and documentation badges to `README.md`.
* Add CI badges to Cargo manifests.