### PR TITLE
Reorder imports and run cargo fmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/rust:1.29.0
+      - image: circleci/rust:1.33.0
 
     environment:
       TZ: "/usr/share/zoneinfo/Asia/Singapore"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 * Minor code formatting tweaks.
+* Switch to Circle CI Rust 1.33.0 image.
 
 ## [0.4.0] - 2018-09-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * Add CI and documentation badges.
 
+### Changed
+* Minor code formatting tweaks.
+
 ## [0.4.0] - 2018-09-16
 ### Added
 * Create `renderdoc-sys` crate for raw FFI bindings.

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -27,7 +27,7 @@ use renderdoc::{OverlayBits, RenderDoc, V110};
 pub type ColorFormat = gfx::format::Rgba8;
 pub type DepthFormat = gfx::format::DepthStencil;
 
-gfx_defines!{
+gfx_defines! {
     vertex Vertex {
         pos: [f32; 2] = "a_Pos",
         color: [f32; 3] = "a_Color",
@@ -74,7 +74,8 @@ pub fn main() {
             include_bytes!("shader/triangle_150.glslv"),
             include_bytes!("shader/triangle_150.glslf"),
             pipe::new(),
-        ).unwrap();
+        )
+        .unwrap();
     let (vertex_buffer, slice) = factory.create_vertex_buffer_with_slice(&TRIANGLE, ());
     let mut data = pipe::Data {
         vbuf: vertex_buffer,

--- a/renderdoc-derive/src/lib.rs
+++ b/renderdoc-derive/src/lib.rs
@@ -66,7 +66,8 @@ fn build_api_list(attrs: &[Attribute]) -> Vec<Ident> {
             .flat_map(|elem| match elem {
                 NestedMeta::Meta(Meta::Word(ident)) => Some(ident),
                 _ => None,
-            }).collect(),
+            })
+            .collect(),
         _ => panic!("Expected list attribute `#[renderdoc_convert(...)]`"),
     };
 
@@ -122,7 +123,8 @@ fn gen_from_impls(name: &Ident, apis: &[Ident], tokens: TokenStream2) -> TokenSt
                     }
                 }
             }
-        }).collect();
+        })
+        .collect();
 
     gen_from_impls(
         name,
@@ -194,7 +196,8 @@ fn gen_renderdoc_impls(name: &Ident, apis: &[Ident], tokens: TokenStream2) -> To
                     }
                 }
             }
-        }).collect();
+        })
+        .collect();
 
     gen_renderdoc_impls(
         name,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,11 +1,11 @@
 //! Traits providing statically guaranteed API version compatibility.
 
-use entry::{EntryV100, EntryV110, EntryV111, EntryV112, EntryV120};
-use {CaptureOption, DevicePointer, InputButton, OverlayBits, WindowHandle};
-
 use std::ffi::{CStr, CString};
 use std::path::Path;
 use std::{mem, ptr};
+
+use entry::{EntryV100, EntryV110, EntryV111, EntryV112, EntryV120};
+use {CaptureOption, DevicePointer, InputButton, OverlayBits, WindowHandle};
 
 /// Base implementation of API version 1.0.0.
 pub trait RenderDocV100: Sized {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,5 +1,9 @@
 //! Entry points for the RenderDoc API.
 
+use std::io::Error as IoError;
+use std::path::Path;
+
+use libloading::{Library, Symbol};
 use renderdoc_sys;
 
 /// Entry point for RenderDoc API version 1.0.0.
@@ -12,11 +16,6 @@ pub type EntryV111 = renderdoc_sys::RENDERDOC_API_1_1_1;
 pub type EntryV112 = renderdoc_sys::RENDERDOC_API_1_1_2;
 /// Entry point for RenderDoc API version 1.2.0.
 pub type EntryV120 = renderdoc_sys::RENDERDOC_API_1_2_0;
-
-use std::io::Error as IoError;
-use std::path::Path;
-
-use libloading::{Library, Symbol};
 
 #[cfg(windows)]
 fn get_path() -> &'static Path {


### PR DESCRIPTION
### Changed

* Minor code reformatting tweaks.
* Switch to Circle CI Rust 1.33.0 image so CI can pass.