### PR TITLE
Fix erroneous doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -11,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * Minor code formatting tweaks.
 * Switch to Circle CI Rust 1.33.0 image.
+
+### Fixed
+* Fix erroneous doc comments (#19).
 
 ## [0.4.0] - 2018-09-16
 ### Added

--- a/src/api.rs
+++ b/src/api.rs
@@ -295,7 +295,7 @@ pub trait RenderDocV110: RenderDocV100 {
 
 /// Additional features for API version 1.1.1.
 pub trait RenderDocV111: RenderDocV110 {
-    /// Returns the raw `EntryV110` entry point struct.
+    /// Returns the raw `EntryV111` entry point struct.
     unsafe fn entry_v111(&self) -> &EntryV111;
 
     #[allow(missing_docs)]
@@ -311,9 +311,9 @@ pub trait RenderDocV111: RenderDocV110 {
     }
 }
 
-/// Additional features for API version 1.1.1.
+/// Additional features for API version 1.1.2.
 pub trait RenderDocV112: RenderDocV111 {
-    /// Returns the raw `EntryV110` entry point struct.
+    /// Returns the raw `EntryV112` entry point struct.
     unsafe fn entry_v112(&self) -> &EntryV112;
 
     #[allow(missing_docs)]
@@ -344,7 +344,7 @@ pub trait RenderDocV112: RenderDocV111 {
 
 /// Additional features for API version 1.2.0.
 pub trait RenderDocV120: RenderDocV112 {
-    /// Returns the raw `EntryV110` entry point struct.
+    /// Returns the raw `EntryV210` entry point struct.
     unsafe fn entry_v120(&self) -> &EntryV120;
 
     #[allow(missing_docs)]


### PR DESCRIPTION
### Fixed

* Correct erroneous doc comments in `src/api.rs`.

Fixes #19.