### PR TITLE
Fix some soundness bugs with RenderDoc struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 * Fix erroneous doc comments (PR #24).
+* Unimplement `Clone`, `Send`, and `Sync` for `RenderDoc` (PR #29).
 
 ## [0.4.0] - 2018-09-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Switch to Circle CI Rust 1.33.0 image.
 
 ### Fixed
-* Fix erroneous doc comments (#19).
+* Fix erroneous doc comments (PR #24).
 
 ## [0.4.0] - 2018-09-16
 ### Added

--- a/renderdoc-derive/src/lib.rs
+++ b/renderdoc-derive/src/lib.rs
@@ -119,7 +119,8 @@ fn gen_from_impls(name: &Ident, apis: &[Ident], tokens: TokenStream2) -> TokenSt
             quote! {
                 impl From<#name<#newer>> for #name<#older> {
                     fn from(newer: #name<#newer>) -> Self {
-                        #name(newer.0.into())
+                        let #name(entry, phantom) = newer;
+                        #name(entry.into(), phantom)
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate wio;
 
 pub use self::entry::{ApiVersion, V100, V110, V111, V112, V120};
 
+use std::marker::PhantomData;
 use std::os::raw::{c_ulonglong, c_void};
 use std::u32;
 
@@ -388,15 +389,15 @@ bitflags! {
 pub type WindowHandle = *const c_void;
 
 /// An instance of the RenderDoc API with baseline version `V`.
-#[derive(Clone, Debug, RenderDoc)]
+#[derive(Debug, RenderDoc)]
 #[renderdoc_convert(V100, V110, V111, V112, V120)]
-pub struct RenderDoc<V: ApiVersion>(V::Entry);
+pub struct RenderDoc<V: ApiVersion>(V::Entry, PhantomData<*mut ()>);
 
 impl<V: ApiVersion> RenderDoc<V> {
     /// Initializes a new instance of the RenderDoc API.
     pub fn new() -> Result<RenderDoc<V>, String> {
         let api = V::load()?;
-        Ok(RenderDoc(api))
+        Ok(RenderDoc(api, PhantomData))
     }
 
     /// Returns the raw entry point of the API.


### PR DESCRIPTION
### Fixed

* Unimplement `Clone`, `Send`, and `Sync` traits for `RenderDoc` struct.

Fixes #25.
Fixes #26.