### PR TITLE
Add missing trait re-exports in prelude module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fix improperly designed `launch_replay_ui()` method, update `triangle` example
   to match.
 * Set correct RenderDoc library path for Android clients.
+* Add missing trait re-exports to `prelude` module (PR #31).
 
 ## [0.4.0] - 2018-09-16
 ### Added

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
 //! Contains common types that can be glob-imported (`*`) for convenience.
 
-pub use api::{RenderDocV100, RenderDocV110, RenderDocV111, RenderDocV112};
+pub use api::*;
 pub use entry::ApiVersion;


### PR DESCRIPTION
### Fixed

* Add missing trait re-exports in `prelude` module.

Fixes #20.