### PR TITLE
Prepare for release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0] - 2019-05-19
 ### Added
 * Add CI and documentation badges.
 * Implement support for API versions 1.3.0 and 1.4.0.
@@ -68,7 +70,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Type-safe version requests and downgrading.
 * Convenient conversions for `winit::VirtualKeyCode` into RenderDoc `InputButton`.
 
-[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "RenderDoc application bindings for Rust"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ default = ["glutin"]
 [dependencies]
 bitflags = "1.0"
 lazy_static = "1.0"
-renderdoc-derive = { version = "0.4.0", path = "./renderdoc-derive" }
-renderdoc-sys = { version = "0.4.0", path = "./renderdoc-sys" }
+renderdoc-derive = { version = "0.5.0", path = "./renderdoc-derive" }
+renderdoc-sys = { version = "0.5.0", path = "./renderdoc-sys" }
 libloading = "0.5"
 
 glutin = { version = "0.21", optional = true }

--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc-derive"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal custom derive macro intended for renderdoc-rs"
 license = "MIT OR Apache-2.0"

--- a/renderdoc-sys/Cargo.toml
+++ b/renderdoc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc-sys"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Raw FFI bindings to the RenderDoc API"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed

* Bump crate versions to 0.5.0.
* Update `CHANGELOG.md` to point to new release tag.