### PR TITLE
Manually implement Debug, derive Eq, Hash, and PartialEq

### DIFF
--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -1,6 +1,7 @@
 //! Type-safe wrapper around the RenderDoc API.
 
 use std::ffi::{CStr, CString};
+use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
@@ -12,7 +13,7 @@ use version::{Entry, HasPrevious, Version, V100, V110, V111, V112, V120, V130, V
 
 /// An instance of the RenderDoc API with baseline version `V`.
 #[repr(C)]
-#[derive(Debug, RenderDoc)]
+#[derive(Eq, Hash, PartialEq, RenderDoc)]
 #[renderdoc_convert(V100, V110, V111, V112, V120, V130, V140)]
 pub struct RenderDoc<V>(*mut Entry, PhantomData<V>);
 
@@ -71,6 +72,15 @@ impl<V: HasPrevious> DerefMut for RenderDoc<V> {
         // the RenderDoc API is the exact same structure. This call only serves to recursively
         // expose the methods in a statically guaranteed and backwards-compatible way.
         unsafe { mem::transmute(self) }
+    }
+}
+
+impl<V: Version> Debug for RenderDoc<V> {
+    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
+        fmt.debug_tuple(stringify!(RenderDoc))
+            .field(&self.0)
+            .field(&V::VERSION)
+            .finish()
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -94,7 +94,7 @@ pub trait HasPrevious: Version {
 }
 
 /// Requests a minimum version number of 1.0.0.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum V100 {}
 
 impl Version for V100 {
@@ -102,7 +102,7 @@ impl Version for V100 {
 }
 
 /// Requests a minimum version number of 1.1.0.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum V110 {}
 
 impl Version for V110 {
@@ -114,7 +114,7 @@ impl HasPrevious for V110 {
 }
 
 /// Requests a minimum version number of 1.1.1.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum V111 {}
 
 impl Version for V111 {
@@ -126,7 +126,7 @@ impl HasPrevious for V111 {
 }
 
 /// Requests a minimum version number of 1.1.2.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum V112 {}
 
 impl Version for V112 {
@@ -138,7 +138,7 @@ impl HasPrevious for V112 {
 }
 
 /// Requests a minimum version number of 1.2.0.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum V120 {}
 
 impl Version for V120 {
@@ -150,7 +150,7 @@ impl HasPrevious for V120 {
 }
 
 /// Requests a minimum version number of 1.3.0.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum V130 {}
 
 impl Version for V130 {
@@ -162,7 +162,7 @@ impl HasPrevious for V130 {
 }
 
 /// Requests a minimum version number of 1.4.0.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum V140 {}
 
 impl Version for V140 {


### PR DESCRIPTION
### Changed

* Implement `Debug`, `Eq`, `Hash`, and `PartialEq` for `RenderDoc`.
* Implement `Copy`, `Clone`, `Eq`, `Hash`, `PartialEq` for `V###` types.

Fixes #21.