### PR TITLE
Deprecate is_remote_access_connected() when using newer APIs

### DIFF
--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -22,7 +22,7 @@ extern crate renderdoc;
 use gfx::traits::FactoryExt;
 use gfx::Device;
 use glutin::GlProfile;
-use renderdoc::{RenderDoc, V100, V110};
+use renderdoc::{RenderDoc, V110};
 
 pub type ColorFormat = gfx::format::Rgba8;
 pub type DepthFormat = gfx::format::DepthStencil;

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -340,6 +340,13 @@ impl RenderDoc<V110> {
 
 impl RenderDoc<V111> {
     #[allow(missing_docs)]
+    #[deprecated(since = "1.1.1", note = "renamed to `is_target_control_connected()`")]
+    pub fn is_remote_access_connected(&self) -> bool {
+        let v1: &RenderDoc<V100> = self.deref();
+        v1.is_remote_access_connected()
+    }
+
+    #[allow(missing_docs)]
     pub fn is_target_control_connected(&self) -> bool {
         unsafe { ((*self.0).__bindgen_anon_3.IsTargetControlConnected.unwrap())() == 1 }
     }


### PR DESCRIPTION
### Deprecated

* Mark `is_remote_access_connected()` as deprecated for all versions after 1.1.1.