### PR TITLE
Apply Clippy suggestions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ default = ["glutin"]
 
 [dependencies]
 bitflags = "1.0"
+float-cmp = "0.4"
 lazy_static = "1.0"
+libloading = "0.5"
 renderdoc-derive = { version = "0.5.0", path = "./renderdoc-derive" }
 renderdoc-sys = { version = "0.5.0", path = "./renderdoc-sys" }
-libloading = "0.5"
 
 glutin = { version = "0.21", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub const SHADER_MAGIC_DEBUG_VALUE_BYTE_ARRAY: &[u8] = &[
 /// to match up with a stripped shader.
 ///
 /// Truncated version when only a `uint64_t` is available (e.g. Vulkan tags).
-pub const SHADER_MAGIC_DEBUG_VALUE_TRUNCATED: c_ulonglong = 0x4856670eab25520;
+pub const SHADER_MAGIC_DEBUG_VALUE_TRUNCATED: c_ulonglong = 0x0485_6670_eab2_5520;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ compile_error!("RenderDoc does not support this platform.");
 
 #[macro_use]
 extern crate bitflags;
+extern crate float_cmp;
 extern crate libloading;
 #[macro_use]
 extern crate lazy_static;

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -64,7 +64,7 @@ impl<V: HasPrevious> Deref for RenderDoc<V> {
         // NOTE: This transmutation is actually safe because the underlying entry point exposed by
         // the RenderDoc API is the exact same structure. This call only serves to recursively
         // expose the methods in a statically guaranteed and backwards-compatible way.
-        unsafe { mem::transmute(self) }
+        unsafe { &*(self as *const RenderDoc<V> as *const RenderDoc<<V as HasPrevious>::Previous>) }
     }
 }
 
@@ -73,7 +73,7 @@ impl<V: HasPrevious> DerefMut for RenderDoc<V> {
         // NOTE: This transmutation is actually safe because the underlying entry point exposed by
         // the RenderDoc API is the exact same structure. This call only serves to recursively
         // expose the methods in a statically guaranteed and backwards-compatible way.
-        unsafe { mem::transmute(self) }
+        unsafe { &mut *(self as *mut RenderDoc<V> as *mut RenderDoc<<V as HasPrevious>::Previous>) }
     }
 }
 

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -7,6 +7,8 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::{mem, ptr};
 
+use float_cmp::ApproxEq;
+
 use handles::{DevicePointer, WindowHandle};
 use settings::{CaptureOption, InputButton, OverlayBits};
 use version::{Entry, HasPrevious, Version, V100, V110, V111, V112, V120, V130, V140};
@@ -139,7 +141,7 @@ impl RenderDoc<V100> {
     pub fn get_capture_option_f32(&self, opt: CaptureOption) -> f32 {
         use std::f32::MAX;
         let val = unsafe { ((*self.0).GetCaptureOptionF32.unwrap())(opt as u32) };
-        assert_ne!(val, -MAX);
+        assert!(val.approx_ne(&-MAX, std::f32::EPSILON, 2));
         val
     }
 

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -263,7 +263,7 @@ impl RenderDoc<V100> {
         let command_str = extra_opts
             .as_ref()
             .map(|s| s.as_ptr())
-            .unwrap_or_else(|| ptr::null());
+            .unwrap_or_else(ptr::null);
 
         unsafe {
             match ((*self.0).LaunchReplayUI.unwrap())(should_connect, command_str) {
@@ -390,7 +390,7 @@ impl RenderDoc<V120> {
         let path = path_str
             .as_ref()
             .map(|s| s.as_ptr())
-            .unwrap_or_else(|| ptr::null());
+            .unwrap_or_else(ptr::null);
 
         let comments = CString::new(comments.as_ref()).expect("string contains extra null bytes");
 

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -5,7 +5,7 @@ use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
-use std::{mem, ptr};
+use std::ptr;
 
 use float_cmp::ApproxEq;
 
@@ -204,9 +204,9 @@ impl RenderDoc<V100> {
     #[allow(missing_docs)]
     pub fn set_log_file_path_template<P: AsRef<Path>>(&mut self, path_template: P) {
         unsafe {
-            let bytes = mem::transmute(path_template.as_ref().as_os_str());
-            let cstr = CStr::from_bytes_with_nul_unchecked(bytes);
-            ((*self.0).__bindgen_anon_1.SetLogFilePathTemplate.unwrap())(cstr.as_ptr());
+            let utf8 = path_template.as_ref().to_str();
+            let path = utf8.and_then(|s| CString::new(s).ok()).unwrap();
+            ((*self.0).__bindgen_anon_1.SetLogFilePathTemplate.unwrap())(path.as_ptr());
         }
     }
 
@@ -258,15 +258,12 @@ impl RenderDoc<V100> {
     where
         O: Into<Option<&'a str>>,
     {
-        let extra_opts = extra_opts.into().and_then(|s| CString::new(s).ok());
         let should_connect = connect_immediately as u32;
-        let command_str = extra_opts
-            .as_ref()
-            .map(|s| s.as_ptr())
-            .unwrap_or_else(ptr::null);
+        let utf8 = extra_opts.into().and_then(|s| CString::new(s).ok());
+        let extra_opts = utf8.as_ref().map(|s| s.as_ptr()).unwrap_or_else(ptr::null);
 
         unsafe {
-            match ((*self.0).LaunchReplayUI.unwrap())(should_connect, command_str) {
+            match ((*self.0).LaunchReplayUI.unwrap())(should_connect, extra_opts) {
                 0 => Err(()),
                 pid => Ok(pid),
             }
@@ -368,9 +365,9 @@ impl RenderDoc<V112> {
 
     #[allow(missing_docs)]
     pub fn set_capture_file_path_template<P: AsRef<Path>>(&mut self, path_template: P) {
+        let utf8 = path_template.as_ref().to_str();
+        let cstr = utf8.and_then(|s| CString::new(s).ok()).unwrap();
         unsafe {
-            let bytes = mem::transmute(path_template.as_ref().as_os_str());
-            let cstr = CStr::from_bytes_with_nul_unchecked(bytes);
             ((*self.0)
                 .__bindgen_anon_1
                 .SetCaptureFilePathTemplate
@@ -386,11 +383,8 @@ impl RenderDoc<V120> {
         P: Into<Option<&'a str>>,
         C: AsRef<str>,
     {
-        let path_str = path.into().and_then(|s| CString::new(s).ok());
-        let path = path_str
-            .as_ref()
-            .map(|s| s.as_ptr())
-            .unwrap_or_else(ptr::null);
+        let utf8 = path.into().and_then(|s| CString::new(s).ok());
+        let path = utf8.as_ref().map(|s| s.as_ptr()).unwrap_or_else(ptr::null);
 
         let comments = CString::new(comments.as_ref()).expect("string contains extra null bytes");
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -74,7 +74,7 @@ pub trait Version {
         use std::ptr;
 
         unsafe {
-            let lib = RD_LIB.as_ref().map_err(|e| e.to_string())?;
+            let lib = RD_LIB.as_ref().map_err(ToString::to_string)?;
             let get_api: Symbol<GetApiFn> =
                 lib.get(b"RENDERDOC_GetAPI\0").map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
### Added

* Add `float_cmp` crate dependency.
* Add underscore separators to `SHADER_MAGIC_DEBUG_VALUE_TRUNCATED` constant.

### Changed

* Use `float_cmp::ApproxEq` when comparing `f32` values.
* Use `as` casts for transmuting between `RenderDoc<V>` in `Deref` and `DerefMut` implementations.

### Removed

* Remove unnecessary closure surrounding `std::ptr::null()` call.
* Eliminate `std::mem::transmute()` and `CStr::from_bytes_with_nul_unchecked()`
* Remove unnecessary closure surrounding `e.to_string()`.