### PR TITLE
Switch to Rust 1.31 in CircleCI and enable all tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/rust:1.34.1
+      - image: circleci/rust:1.31.0
 
     environment:
       TZ: "/usr/share/zoneinfo/Asia/Singapore"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/rust:1.31.0
+      - image: ebkalderon/renderdoc-rs-circleci:1.31.0
 
     environment:
       TZ: "/usr/share/zoneinfo/Asia/Singapore"
@@ -23,18 +23,17 @@ jobs:
             rustup toolchain add nightly
             rustup run nightly rustc --version --verbose
             rustup run nightly cargo --version --verbose
-            rustup run nightly cargo build
+            rustup run nightly cargo build --all
       - run:
           name: Stable Build
           command: |
             rustc --version --verbose
             cargo --version --verbose
-            cargo build
+            cargo build --all
       - run:
           name: Test
           command: |
-            cargo test --no-run
-            cargo test -p renderdoc-sys
+            cargo test --all
       - save_cache:
           key: project-cache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: Check formatting
           command: |
             rustup component add rustfmt
-            cargo fmt -- --check
+            cargo fmt --all -- --check
       - run:
           name: Nightly Build
           command: |


### PR DESCRIPTION
### Changed

* Change `cargo fmt` to `cargo fmt --all` in CircleCI.
* Switch minimum required Rust version in CircleCI to 1.31.0.
* Switch to custom Rust CircleCI image with RenderDoc ([ebkalderon/renderdoc-rs-circleci-dockerfile](https://github.com/ebkalderon/renderdoc-rs-circleci-dockerfile/)).
* Enable all unit tests and doc tests in CircleCI.

This pull request should allow all tests (including doc tests) to be compiled and run automatically before merging, preventing failure cases in CI like in #44 from happening again.