### PR TITLE
Prepare for release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.6.0] - 2019-05-19
+### Added
+* Redesign crate to use inherent impls over traits (PR #35).
+* Add `HasPrevious` trait to recursively determine version compatibility at
+  compile-time.
+
+### Changed
+* Rename `Version` enum to `VersionCode` and `ApiVersion` trait to `Version`.
+* Use a single `Entry` type, since the aliases point to the same struct.
+* Update crate metadata and improve documentation.
+* Manually implement `Debug`, derive `Eq`, `Hash`, `PartialEq` for most types
+  (PR #41).
+* Apply Clippy suggestions (PR #43).
+
+### Deprecated
+* Mark `is_remote_access_connected()` as deprecated for all RenderDoc API
+  versions after 1.1.1 (PR #42).
+
+### Removed
+* Remove `prelude` module.
+* Remove `RenderDocV###` traits.
+* Remove `RenderDocV###` trait boilerplate code from `renderdoc-derive`.
+* Remove unused `__uint32_t` and `__uint64_t` type aliases from `renderdoc-sys`
+  (PR #39).
+
 ## [0.5.0] - 2019-05-19
 ### Added
 * Add CI and documentation badges.
@@ -70,7 +95,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Type-safe version requests and downgrading.
 * Convenient conversions for `winit::VirtualKeyCode` into RenderDoc `InputButton`.
 
-[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.2.0...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "RenderDoc application bindings for Rust"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,8 @@ bitflags = "1.0"
 float-cmp = "0.4"
 lazy_static = "1.0"
 libloading = "0.5"
-renderdoc-derive = { version = "0.5.0", path = "./renderdoc-derive" }
-renderdoc-sys = { version = "0.5.0", path = "./renderdoc-sys" }
+renderdoc-derive = { version = "0.6", path = "./renderdoc-derive" }
+renderdoc-sys = { version = "0.6", path = "./renderdoc-sys" }
 
 glutin = { version = "0.21", optional = true }
 

--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc-derive"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal custom derive macro intended for renderdoc-rs"
 license = "MIT OR Apache-2.0"

--- a/renderdoc-sys/Cargo.toml
+++ b/renderdoc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc-sys"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Raw FFI bindings to the RenderDoc API"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed

* Bump crate versions to 0.6.0.
* Update `CHANGELOG.md` to point to new release tag.