### PR TITLE
Upgrade syn, quote, and proc-macro2 to 1.0

### DIFF
--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -17,6 +17,6 @@ circle-ci = { repository = "ebkalderon/renderdoc-rs" }
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "0.4.30"
-quote = "0.6.12"
-syn = "0.15.34"
+proc-macro2 = "1.0.0"
+quote = "1.0.0"
+syn = "1.0.1"


### PR DESCRIPTION
### Changed

* Upgrade `syn` dependency in `renderdoc-derive` from version 0.15.34 to 1.0.1.
* Upgrade `proc-macro2` dependency in `renderdoc-derive` from version 0.4.30 to 1.0.0.
* Upgrade `quote` dependency in `renderdoc-derive` from version 0.6.12 to 1.0.0.
* Accommodate for upstream API breakage in `syn` and `proc-macro2` in `renderdoc-derive`.

Closes #52.
Closes #53.
Closes #54.