### PR TITLE
Deprecate renderdoc-derive crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ bitflags = "1.0"
 float-cmp = "0.5"
 lazy_static = "1.0"
 libloading = "0.5"
-renderdoc-derive = { version = "0.6", path = "./renderdoc-derive" }
 renderdoc-sys = { version = "0.6", path = "./renderdoc-sys" }
 
 glutin = { version = "0.21", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,5 @@ gfx_window_glutin = "0.31"
 glutin = "0.21"
 
 [workspace]
-members = [".", "renderdoc-derive", "renderdoc-sys"]
+members = [".", "renderdoc-sys"]
 default-members = [".", "renderdoc-sys"]

--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc-derive"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Internal custom derive macro intended for renderdoc-rs"
 license = "MIT OR Apache-2.0"
@@ -12,6 +12,7 @@ keywords = ["derive", "renderdoc"]
 
 [badges]
 circle-ci = { repository = "ebkalderon/renderdoc-rs" }
+maintenance = { status = "deprecated" }
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,6 @@ extern crate float_cmp;
 extern crate libloading;
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
-extern crate renderdoc_derive;
 extern crate renderdoc_sys;
 
 #[cfg(feature = "glutin")]

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -453,9 +453,10 @@ impl RenderDoc<V140> {
     }
 }
 
-/// Generates `From` implementations that permit downgrading of API versions. Unlike the
-/// `downgrade()` method, these `From` implementations let any version to downgrade to any other
-/// older backwards-compatible API version in a clean way.
+/// Generates `From` implementations that permit downgrading of API versions.
+///
+/// Unlike the `downgrade()` method, these `From` implementations let any version to downgrade to
+/// any other older backwards-compatible API version in a clean way.
 ///
 /// This function takes a list of API versions sorted in ascending order and recursively generates
 /// `From` implementations for them. For instance, given the following three API versions

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -13,8 +13,7 @@ use version::{Entry, HasPrevious, Version, V100, V110, V111, V112, V120, V130, V
 
 /// An instance of the RenderDoc API with baseline version `V`.
 #[repr(C)]
-#[derive(Eq, Hash, PartialEq, RenderDoc)]
-#[renderdoc_convert(V100, V110, V111, V112, V120, V130, V140)]
+#[derive(Eq, Hash, PartialEq)]
 pub struct RenderDoc<V>(*mut Entry, PhantomData<V>);
 
 impl<V: Version> RenderDoc<V> {
@@ -453,3 +452,68 @@ impl RenderDoc<V140> {
         unsafe { ((*self.0).DiscardFrameCapture.unwrap())(dev as *mut _, win as *mut _) == 1 }
     }
 }
+
+/// Generates `From` implementations that permit downgrading of API versions. Unlike the
+/// `downgrade()` method, these `From` implementations let any version to downgrade to any other
+/// older backwards-compatible API version in a clean way.
+///
+/// This function takes a list of API versions sorted in ascending order and recursively generates
+/// `From` implementations for them. For instance, given the following three API versions
+/// `[V200, V110, V100]` (reverse chronological order), these trait implementations will be
+/// generated:
+///
+/// ```rust,ignore
+/// // V200 -> V110, V100
+///
+/// impl From<#name<V200>> for #name<V110>
+/// where
+///     Self: Sized,
+/// {
+///     fn from(newer: #name<V200>) -> Self {
+///         // ...
+///     }
+/// }
+///
+/// impl From<#name<V200>> for #name<V100>
+/// where
+///     Self: Sized,
+/// {
+///     fn from(newer: #name<V200>) -> Self {
+///         // ...
+///     }
+/// }
+///
+/// // V110 -> V100
+///
+/// impl From<#name<V110>> for #name<V100>
+/// where
+///     Self: Sized,
+/// {
+///     fn from(newer: #name<V200>) -> Self {
+///         // ...
+///     }
+/// }
+///
+/// // V100 -> ()
+/// ```
+macro_rules! impl_from_versions {
+    ($base_version:ident) => {};
+
+    ($newer:ident, $($older:ident),+) => {
+        $(
+            impl From<RenderDoc<$newer>> for RenderDoc<$older>
+            where
+                Self: Sized,
+            {
+                fn from(newer: RenderDoc<$newer>) -> Self {
+                    let RenderDoc(entry, _) = newer;
+                    RenderDoc(entry, PhantomData)
+                }
+            }
+        )+
+
+        impl_from_versions!($($older),+);
+    };
+}
+
+impl_from_versions!(V140, V130, V120, V112, V111, V110, V100);


### PR DESCRIPTION
### Added

* Create `impl_from_versions!()` macro in `renderdoc.rs` to replace `renderdoc-derive` procedural macro.

### Changed

* Bump `renderdoc-derive` crate version to 0.7.0, mark deprecated.

### Removed

* Remove main crate dependency on `renderdoc-derive`.