### PR TITLE
Use renderdoc-sys to define all settings enums

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,39 +10,39 @@ use glutin::VirtualKeyCode;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum CaptureOption {
     /// Let the application enable vertical synchronization.
-    AllowVSync = 0,
+    AllowVSync = renderdoc_sys::eRENDERDOC_Option_AllowVSync,
     /// Let the application enter fullscreen mode.
-    AllowFullscreen = 1,
+    AllowFullscreen = renderdoc_sys::eRENDERDOC_Option_AllowFullscreen,
     /// Record API debugging events and messages.
     ///
     /// This option also goes by the deprecated name of `DebugDeviceMode`.
-    ApiValidation = 2,
+    ApiValidation = renderdoc_sys::eRENDERDOC_Option_APIValidation,
     /// Capture CPU callstacks for API events.
-    CaptureCallstacks = 3,
+    CaptureCallstacks = renderdoc_sys::eRENDERDOC_Option_CaptureCallstacks,
     /// When capturing CPU callstacks, only capture them from drawcalls.
     ///
     /// This option does nothing without the above option being enabled.
-    CaptureCallstacksOnlyDraws = 4,
+    CaptureCallstacksOnlyDraws = renderdoc_sys::eRENDERDOC_Option_CaptureCallstacksOnlyDraws,
     /// Specify a delay, measured in seconds, to wait for a debugger to attach to the application
     /// after being injected.
-    DelayForDebugger = 5,
+    DelayForDebugger = renderdoc_sys::eRENDERDOC_Option_DelayForDebugger,
     /// Verify any writes to mapped buffers by checking the memory after the bounds of the
     /// returned pointer to detect any modification.
-    VerifyMapWrites = 6,
+    VerifyMapWrites = renderdoc_sys::eRENDERDOC_Option_VerifyMapWrites,
     /// Hooks any system API calls that create child processes and injects RenderDoc into them
     /// recursively with the same options.
-    HookIntoChildren = 7,
+    HookIntoChildren = renderdoc_sys::eRENDERDOC_Option_HookIntoChildren,
     /// Reference all resources available at the time of capture.
     ///
     /// By default, RenderDoc only includes resources in the final capture file necessary for that
     /// frame. This option allows you to override that behavior.
-    RefAllResources = 8,
+    RefAllResources = renderdoc_sys::eRENDERDOC_Option_RefAllResources,
     /// Save the initial state for all resources, regardless of usage.
     ///
     /// By default, RenderDoc skips saving initial states for resources where the previous
     /// contents don't appear to be used (assuming that writes before reads indicate the previous
     /// contents aren't used).
-    SaveAllInitials = 9,
+    SaveAllInitials = renderdoc_sys::eRENDERDOC_Option_SaveAllInitials,
     /// Capture all command lists generated from the start of the application.
     ///
     /// In APIs that allow for recording of command lists to be replayed later, RenderDoc may
@@ -54,12 +54,13 @@ pub enum CaptureOption {
     /// discouraged. Newer APIs, e.g. Vulkan and D3D12, will ignore this option and always capture
     /// all command lists since they are heavily oriented around them and the associated overhead
     /// is mostly reduced due to superior API design.
-    CaptureAllCmdLists = 10,
+    CaptureAllCmdLists = renderdoc_sys::eRENDERDOC_Option_CaptureAllCmdLists,
     /// Mute API debug output when `CaptureOption::ApiValidation` is enabled.
-    DebugOutputMute = 11,
+    DebugOutputMute = renderdoc_sys::eRENDERDOC_Option_DebugOutputMute,
     /// Allow all vendor extensions to be used, even when they may be incompatible with RenderDoc
     /// and could potentially cause corrupted replays or crashes.
-    AllowUnsupportedVendorExtensions = 12,
+    AllowUnsupportedVendorExtensions =
+        renderdoc_sys::eRENDERDOC_Option_AllowUnsupportedVendorExtensions,
 }
 
 /// User input key codes.
@@ -68,92 +69,92 @@ pub enum CaptureOption {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum InputButton {
     /// The '0' key over the letters.
-    Key0 = 0x30,
+    Key0 = renderdoc_sys::eRENDERDOC_Key_0,
     /// The '1' key over the letters.
-    Key1 = 0x31,
+    Key1 = renderdoc_sys::eRENDERDOC_Key_1,
     /// The '2' key over the letters.
-    Key2 = 0x32,
+    Key2 = renderdoc_sys::eRENDERDOC_Key_2,
     /// The '3' key over the letters.
-    Key3 = 0x33,
+    Key3 = renderdoc_sys::eRENDERDOC_Key_3,
     /// The '4' key over the letters.
-    Key4 = 0x34,
+    Key4 = renderdoc_sys::eRENDERDOC_Key_4,
     /// The '5' key over the letters.
-    Key5 = 0x35,
+    Key5 = renderdoc_sys::eRENDERDOC_Key_5,
     /// The '6' key over the letters.
-    Key6 = 0x36,
+    Key6 = renderdoc_sys::eRENDERDOC_Key_6,
     /// The '7' key over the letters.
-    Key7 = 0x37,
+    Key7 = renderdoc_sys::eRENDERDOC_Key_7,
     /// The '8' key over the letters.
-    Key8 = 0x38,
+    Key8 = renderdoc_sys::eRENDERDOC_Key_8,
     /// The '9' key over the letters.
-    Key9 = 0x39,
+    Key9 = renderdoc_sys::eRENDERDOC_Key_9,
 
-    A = 0x41,
-    B = 0x42,
-    C = 0x43,
-    D = 0x44,
-    E = 0x45,
-    F = 0x46,
-    G = 0x47,
-    H = 0x48,
-    I = 0x49,
-    J = 0x4A,
-    K = 0x4B,
-    L = 0x4C,
-    M = 0x4D,
-    N = 0x4E,
-    O = 0x4F,
-    P = 0x50,
-    Q = 0x51,
-    R = 0x52,
-    S = 0x53,
-    T = 0x54,
-    U = 0x55,
-    V = 0x56,
-    W = 0x57,
-    X = 0x58,
-    Y = 0x59,
-    Z = 0x5A,
+    A = renderdoc_sys::eRENDERDOC_Key_A,
+    B = renderdoc_sys::eRENDERDOC_Key_B,
+    C = renderdoc_sys::eRENDERDOC_Key_C,
+    D = renderdoc_sys::eRENDERDOC_Key_D,
+    E = renderdoc_sys::eRENDERDOC_Key_E,
+    F = renderdoc_sys::eRENDERDOC_Key_F,
+    G = renderdoc_sys::eRENDERDOC_Key_G,
+    H = renderdoc_sys::eRENDERDOC_Key_H,
+    I = renderdoc_sys::eRENDERDOC_Key_I,
+    J = renderdoc_sys::eRENDERDOC_Key_J,
+    K = renderdoc_sys::eRENDERDOC_Key_K,
+    L = renderdoc_sys::eRENDERDOC_Key_L,
+    M = renderdoc_sys::eRENDERDOC_Key_M,
+    N = renderdoc_sys::eRENDERDOC_Key_N,
+    O = renderdoc_sys::eRENDERDOC_Key_O,
+    P = renderdoc_sys::eRENDERDOC_Key_P,
+    Q = renderdoc_sys::eRENDERDOC_Key_Q,
+    R = renderdoc_sys::eRENDERDOC_Key_R,
+    S = renderdoc_sys::eRENDERDOC_Key_S,
+    T = renderdoc_sys::eRENDERDOC_Key_T,
+    U = renderdoc_sys::eRENDERDOC_Key_U,
+    V = renderdoc_sys::eRENDERDOC_Key_V,
+    W = renderdoc_sys::eRENDERDOC_Key_W,
+    X = renderdoc_sys::eRENDERDOC_Key_X,
+    Y = renderdoc_sys::eRENDERDOC_Key_Y,
+    Z = renderdoc_sys::eRENDERDOC_Key_Z,
 
     /// Leave the rest of the ASCII range free, in case the RenderDoc developers decide to use it
     /// later.
-    NonPrintable = 0x100,
+    NonPrintable = renderdoc_sys::eRENDERDOC_Key_NonPrintable,
 
     /// Division key on the numpad.
-    Divide,
+    Divide = renderdoc_sys::eRENDERDOC_Key_Divide,
     /// Multiplication key on the numpad.
-    Multiply,
+    Multiply = renderdoc_sys::eRENDERDOC_Key_Multiply,
     /// Subtraction key on the numpad.
-    Subtract,
+    Subtract = renderdoc_sys::eRENDERDOC_Key_Subtract,
     /// Addition key on the numpad.
-    Plus,
+    Plus = renderdoc_sys::eRENDERDOC_Key_Plus,
 
-    F1,
-    F2,
-    F3,
-    F4,
-    F5,
-    F6,
-    F7,
-    F8,
-    F9,
-    F10,
-    F11,
-    F12,
+    F1 = renderdoc_sys::eRENDERDOC_Key_F1,
+    F2 = renderdoc_sys::eRENDERDOC_Key_F2,
+    F3 = renderdoc_sys::eRENDERDOC_Key_F3,
+    F4 = renderdoc_sys::eRENDERDOC_Key_F4,
+    F5 = renderdoc_sys::eRENDERDOC_Key_F5,
+    F6 = renderdoc_sys::eRENDERDOC_Key_F6,
+    F7 = renderdoc_sys::eRENDERDOC_Key_F7,
+    F8 = renderdoc_sys::eRENDERDOC_Key_F8,
+    F9 = renderdoc_sys::eRENDERDOC_Key_F9,
+    F10 = renderdoc_sys::eRENDERDOC_Key_F10,
+    F11 = renderdoc_sys::eRENDERDOC_Key_F11,
+    F12 = renderdoc_sys::eRENDERDOC_Key_F12,
 
-    Home,
-    End,
-    Insert,
-    Delete,
-    PageUp,
-    PageDn,
+    Home = renderdoc_sys::eRENDERDOC_Key_Home,
+    End = renderdoc_sys::eRENDERDOC_Key_End,
+    Insert = renderdoc_sys::eRENDERDOC_Key_Insert,
+    Delete = renderdoc_sys::eRENDERDOC_Key_Delete,
+    PageUp = renderdoc_sys::eRENDERDOC_Key_PageUp,
+    PageDn = renderdoc_sys::eRENDERDOC_Key_PageDn,
 
-    Backspace,
-    Tab,
-    PrtScrn,
-    Pause,
+    Backspace = renderdoc_sys::eRENDERDOC_Key_Backspace,
+    Tab = renderdoc_sys::eRENDERDOC_Key_Tab,
+    PrtScrn = renderdoc_sys::eRENDERDOC_Key_PrtScrn,
+    Pause = renderdoc_sys::eRENDERDOC_Key_Pause,
 
-    Max,
+    Max = renderdoc_sys::eRENDERDOC_Key_Max,
 }
 
 #[cfg(feature = "glutin")]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -232,15 +232,15 @@ bitflags! {
     /// Bit flags for customizing the RenderDoc overlay.
     pub struct OverlayBits: u32 {
         /// Controls whether the overlay is enabled or disabled globally.
-        const ENABLED = 0x1;
+        const ENABLED = renderdoc_sys::eRENDERDOC_Overlay_Enabled;
         /// Shows the average, minimum, and maximum sampled frame rate.
-        const FRAME_RATE = 0x2;
+        const FRAME_RATE = renderdoc_sys::eRENDERDOC_Overlay_FrameRate;
         /// Shows the current frame number.
-        const FRAME_NUMBER = 0x4;
+        const FRAME_NUMBER = renderdoc_sys::eRENDERDOC_Overlay_FrameNumber;
         /// Shows a list of recent captures, out of the total captures made.
-        const CAPTURE_LIST = 0x8;
+        const CAPTURE_LIST = renderdoc_sys::eRENDERDOC_Overlay_CaptureList;
         /// Sets the default configuration for the overlay.
-        const DEFAULT = (0x1 | 0x2 | 0x4 | 0x8);
+        const DEFAULT = renderdoc_sys::eRENDERDOC_Overlay_Default;
         /// Enables all overlay configuration bits.
         const ALL = u32::MAX;
         /// Disables all overlay configuration bits.


### PR DESCRIPTION
### Changed

* Use `renderdoc-sys` values to define `CaptureOptions` and `InputButton` enums.
* Use `renderdoc-sys` values to define `OverlayBits` bitflags.