### PR TITLE
Hide duplicate Deref methods from rustdoc for readability

### DIFF
--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -66,6 +66,7 @@ impl<V: HasPrevious> RenderDoc<V> {
     }
 }
 
+#[doc(hidden)]
 impl<V: HasPrevious> Deref for RenderDoc<V> {
     type Target = RenderDoc<V::Previous>;
 


### PR DESCRIPTION
### Changed

* Clean up `rustdoc` output for `RenderDoc` struct by marking its `Deref` implementation as `#[doc(hidden)]`.

This should just be a cosmetic change and not affect the visibility rules in code editors relying on RLS or `rust-analyzer`.