### PR TITLE
Minor tweaks made during release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Bump `float-cmp` dependency to 0.5.
 * Switch to Circle CI Rust 1.33.0 image.
 * Change error type of `launch_replay_ui()` from `()` to `String`.
-* Mark `Deref` block with `#[doc(hidden)]` for cleaner generated docs.
+* Mark `Deref` block as `#[doc(hidden)]` for cleaner generated docs.
 
 ### Removed
 * Remove internal `renderdoc-derive` crate in favor of declarative macro.

--- a/renderdoc-derive/Cargo.toml
+++ b/renderdoc-derive/Cargo.toml
@@ -21,3 +21,5 @@ proc-macro = true
 proc-macro2 = "1.0.0"
 quote = "1.0.0"
 syn = "1.0.1"
+
+[workspace]


### PR DESCRIPTION
### Added

* Add empty workspace key to the `Cargo.toml` of `renderdoc-derive`.

### Changed

* Tweak wording of `CHANGELOG.md`.