### PR TITLE
Simplify badge Markdown in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # renderdoc-rs
 
-[![Build Status][s1]][cc] [![Crates.io][s2]][ci] [![Documentation][s3]][docs]
+[![Build Status][build-badge]][build-url]
+[![Crates.io][crate-badge]][crate-url]
+[![Documentation][docs-badge]][docs-url]
 
-[s1]: https://circleci.com/gh/ebkalderon/renderdoc-rs.svg?style=shield
-[cc]: https://circleci.com/gh/ebkalderon/renderdoc-rs
-[s2]: https://img.shields.io/crates/v/renderdoc.svg
-[ci]: https://crates.io/crates/renderdoc
-[s3]: https://img.shields.io/badge/docs-master-blue.svg
-[docs]: https://docs.rs/renderdoc
+[build-badge]: https://circleci.com/gh/ebkalderon/renderdoc-rs.svg?style=shield
+[build-url]: https://circleci.com/gh/ebkalderon/renderdoc-rs
+[crate-badge]: https://img.shields.io/crates/v/renderdoc.svg
+[crate-url]: https://crates.io/crates/renderdoc
+[docs-badge]: https://docs.rs/renderdoc/badge.svg
+[docs-url]: https://docs.rs/renderdoc
 
 Rust bindings to [RenderDoc], a popular graphics debugger.
 

--- a/renderdoc-sys/README.md
+++ b/renderdoc-sys/README.md
@@ -1,13 +1,15 @@
 # renderdoc-sys
 
-[![Build Status][s1]][cc] [![Crates.io][s2]][ci] [![Documentation][s3]][docs]
+[![Build Status][build-badge]][build-url]
+[![Crates.io][crate-badge]][crate-url]
+[![Documentation][docs-badge]][docs-url]
 
-[s1]: https://circleci.com/gh/ebkalderon/renderdoc-rs.svg?style=shield
-[cc]: https://circleci.com/gh/ebkalderon/renderdoc-rs/tree/master/renderdoc-sys
-[s2]: https://img.shields.io/crates/v/renderdoc.svg
-[ci]: https://crates.io/crates/renderdoc-sys
-[s3]: https://img.shields.io/badge/docs-master-blue.svg
-[docs]: https://docs.rs/renderdoc-sys
+[build-badge]: https://circleci.com/gh/ebkalderon/renderdoc-rs.svg?style=shield
+[build-url]: https://circleci.com/gh/ebkalderon/renderdoc-rs/tree/master/renderdoc-sys
+[crate-badge]: https://img.shields.io/crates/v/renderdoc-sys.svg
+[crate-url]: https://crates.io/crates/renderdoc-sys
+[docs-badge]: https://docs.rs/renderdoc-sys/badge.svg
+[docs-url]: https://docs.rs/renderdoc-sys
 
 Low-level Rust FFI bindings to [RenderDoc], a popular graphics debugger.
 


### PR DESCRIPTION
### Changed

* Simplify badge Markdown in `README.md` for `renderdoc` crate.
* Simplify badge Markdown in `README.md` for `renderdoc-sys` crate.