### PR TITLE
Switch to Rust 1.36 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ebkalderon/renderdoc-rs-circleci:1.33.0
+      - image: ebkalderon/renderdoc-rs-circleci:1.36.0
 
     environment:
       TZ: "/usr/share/zoneinfo/Asia/Singapore"


### PR DESCRIPTION
### Changed

* Switch to Rust 1.36 in CircleCI to fix upstream `stb_truetype` 0.3.0 breakage.

See ebkalderon/renderdoc-rs-circleci-dockerfile#3 for details.