### PR TITLE
Update copyright year in LICENSE-MIT

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2019 Eyal Kalderon
+Copyright (c) 2020 Eyal Kalderon
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Changed

* Update the copyright year in `LICENSE-MIT` to the current year.

The copyright year range is not necessary in this document since U.S. copyright law does not officially recognize year ranges, and the historical year values are retained safely in Git.