### PR TITLE
Build with stable Rust before building with Nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,9 @@ jobs:
             rustup component add rustfmt
             cargo fmt --all -- --check
       - run:
-          name: Nightly Build
+          name: Test
           command: |
-            rustup toolchain add nightly
-            rustup run nightly rustc --version --verbose
-            rustup run nightly cargo --version --verbose
-            rustup run nightly cargo build --all
+            cargo test --all
       - run:
           name: Stable Build
           command: |
@@ -31,9 +28,12 @@ jobs:
             cargo --version --verbose
             cargo build --all
       - run:
-          name: Test
+          name: Nightly Build
           command: |
-            cargo test --all
+            rustup toolchain add nightly
+            rustup run nightly rustc --version --verbose
+            rustup run nightly cargo --version --verbose
+            rustup run nightly cargo build --all
       - save_cache:
           key: project-cache
           paths:


### PR DESCRIPTION
### Fixed

* Fix CircleCI issues with `Cargo.lock` format incompatibility.

Seems like there is an incompatibility with the `Cargo.lock` files generated between older and newer versions of Rust (most likely the new merge-friendly format), which is affecting CircleCI in recent PRs (see #75).

This commit should hopefully allow us to start with an old lockfile, test our changes on stable, and then subsequently upgrade to the new lockfile format with nightly.