### PR TITLE
Improve type ergonomics and add Error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ default = ["glutin"]
 [dependencies]
 bitflags = "1.0"
 float-cmp = "0.7"
-lazy_static = "1.0"
 libloading = "0.6"
+once_cell = "1.0"
 renderdoc-sys = { version = "0.6", path = "./renderdoc-sys" }
 
 glutin = { version = "0.21", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,53 @@
+//! Common library error types.
+
+use std::fmt::{self, Display, Formatter};
+
+/// Errors that can occur with the RenderDoc in-application API.
+#[derive(Debug)]
+pub struct Error(ErrorKind);
+
+impl Error {
+    pub(crate) fn library(cause: libloading::Error) -> Self {
+        Error(ErrorKind::Library(cause))
+    }
+
+    pub(crate) fn symbol(cause: libloading::Error) -> Self {
+        Error(ErrorKind::Symbol(cause))
+    }
+
+    pub(crate) fn no_compatible_api() -> Self {
+        Error(ErrorKind::NoCompatibleApi)
+    }
+
+    pub(crate) fn launch_replay_ui() -> Self {
+        Error(ErrorKind::LaunchReplayUi)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self.0 {
+            ErrorKind::Library(_) => write!(f, "Unable to load RenderDoc shared library"),
+            ErrorKind::Symbol(_) => write!(f, "Unable to find `RENDERDOC_GetAPI` symbol"),
+            ErrorKind::NoCompatibleApi => write!(f, "Library could not provide compatible API"),
+            ErrorKind::LaunchReplayUi => write!(f, "Failed to launch replay UI"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self.0 {
+            ErrorKind::Library(ref e) | ErrorKind::Symbol(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ErrorKind {
+    Library(libloading::Error),
+    Symbol(libloading::Error),
+    NoCompatibleApi,
+    LaunchReplayUi,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,7 @@ extern crate bitflags;
 #[macro_use]
 extern crate float_cmp;
 extern crate libloading;
-#[macro_use]
-extern crate lazy_static;
+extern crate once_cell;
 extern crate renderdoc_sys;
 
 #[cfg(feature = "glutin")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate winapi;
 #[cfg(target_os = "windows")]
 extern crate wio;
 
+pub use self::error::Error;
 pub use self::handles::{DevicePointer, WindowHandle};
 pub use self::renderdoc::RenderDoc;
 pub use self::settings::{CaptureOption, InputButton, OverlayBits};
@@ -45,6 +46,7 @@ use std::os::raw::c_ulonglong;
 #[cfg(windows)]
 use winapi::shared::guiddef::GUID;
 
+mod error;
 mod handles;
 mod renderdoc;
 mod settings;

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -263,9 +263,9 @@ impl RenderDoc<V100> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set_log_file_path_template<P: AsRef<Path>>(&mut self, path_template: P) {
+    pub fn set_log_file_path_template<P: Into<PathBuf>>(&mut self, path_template: P) {
         unsafe {
-            let utf8 = path_template.as_ref().to_str();
+            let utf8 = path_template.into().into_os_string().into_string().ok();
             let path = utf8.and_then(|s| CString::new(s).ok()).unwrap();
             ((*self.0).__bindgen_anon_1.SetLogFilePathTemplate.unwrap())(path.as_ptr());
         }
@@ -587,8 +587,8 @@ impl RenderDoc<V112> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set_capture_file_path_template<P: AsRef<Path>>(&mut self, path_template: P) {
-        let utf8 = path_template.as_ref().to_str();
+    pub fn set_capture_file_path_template<P: Into<PathBuf>>(&mut self, path_template: P) {
+        let utf8 = path_template.into().into_os_string().into_string().ok();
         let cstr = utf8.and_then(|s| CString::new(s).ok()).unwrap();
         unsafe {
             ((*self.0)

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -602,6 +602,8 @@ impl RenderDoc<V112> {
 impl RenderDoc<V120> {
     /// Adds or sets an arbitrary comments field to an existing capture on disk, which will then be
     /// displayed in the UI to anyone opening the capture file.
+    ///
+    /// If the `path` argument is `None`, the most recent previous capture file is used.
     pub fn set_capture_file_comments<'a, P, C>(&mut self, path: P, comments: C)
     where
         P: Into<Option<&'a str>>,

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -4,7 +4,7 @@ use std::ffi::{CStr, CString};
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::ptr;
 
 use handles::{DevicePointer, WindowHandle};
@@ -287,7 +287,7 @@ impl RenderDoc<V100> {
         unsafe { ((*self.0).GetNumCaptures.unwrap())() }
     }
 
-    /// Retrieves the path and capture time of a capture file indexed by the number `index`.
+    /// Retrieves the path and Unix capture time of a capture file indexed by the number `index`.
     ///
     /// Returns `Some` if the index was within `0..get_num_captures()`, otherwise returns `None`.
     ///
@@ -306,7 +306,7 @@ impl RenderDoc<V100> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_capture(&self, index: u32) -> Option<(String, u64)> {
+    pub fn get_capture(&self, index: u32) -> Option<(PathBuf, u64)> {
         let mut len = self.get_log_file_path_template().len() as u32 + 128;
         let mut path = Vec::with_capacity(len as usize);
         let mut time = 0u64;
@@ -317,7 +317,7 @@ impl RenderDoc<V100> {
                 let mut path = raw_path.into_string().unwrap();
                 path.shrink_to_fit();
 
-                Some((path, time))
+                Some((path.into(), time))
             } else {
                 None
             }

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -234,10 +234,10 @@ impl RenderDoc<V100> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_log_file_path_template(&self) -> &str {
+    pub fn get_log_file_path_template(&self) -> &Path {
         unsafe {
             let raw = ((*self.0).__bindgen_anon_2.GetLogFilePathTemplate.unwrap())();
-            CStr::from_ptr(raw).to_str().unwrap()
+            CStr::from_ptr(raw).to_str().map(Path::new).unwrap()
         }
     }
 
@@ -307,7 +307,7 @@ impl RenderDoc<V100> {
     /// # }
     /// ```
     pub fn get_capture(&self, index: u32) -> Option<(PathBuf, u64)> {
-        let mut len = self.get_log_file_path_template().len() as u32 + 128;
+        let mut len = self.get_log_file_path_template().as_os_str().len() as u32 + 128;
         let mut path = Vec::with_capacity(len as usize);
         let mut time = 0u64;
 
@@ -555,13 +555,13 @@ impl RenderDoc<V112> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_capture_file_path_template(&self) -> &str {
+    pub fn get_capture_file_path_template(&self) -> &Path {
         unsafe {
             let raw = ((*self.0)
                 .__bindgen_anon_2
                 .GetCaptureFilePathTemplate
                 .unwrap())();
-            CStr::from_ptr(raw).to_str().unwrap()
+            CStr::from_ptr(raw).to_str().map(Path::new).unwrap()
         }
     }
 

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -608,12 +608,11 @@ impl RenderDoc<V120> {
     pub fn set_capture_file_comments<'a, P, C>(&mut self, path: P, comments: C)
     where
         P: Into<Option<&'a str>>,
-        C: AsRef<str>,
+        C: Into<String>,
     {
         let utf8 = path.into().and_then(|s| CString::new(s).ok());
         let path = utf8.as_ref().map(|s| s.as_ptr()).unwrap_or_else(ptr::null);
-
-        let comments = CString::new(comments.as_ref()).expect("string contains extra null bytes");
+        let comments = CString::new(comments.into()).unwrap();
 
         unsafe {
             ((*self.0).SetCaptureFileComments.unwrap())(path, comments.as_ptr());


### PR DESCRIPTION
### Added

* Add common `Error` type to use throughout the library.

### Changed

* Return `PathBuf` from `get_capture()` instead of `String`.
* Return `&Path` from `get_{log,capture}_file_path_template()` instead of `&str`.
* Accept `Into<PathBuf>` or `Into<String>` in some places to avoid extra allocation if possible.
* Document if `path` argument is `None` in docs for `set_capture_file_comments()`.
* Switch from `lazy_static` to `once_cell`.

These changes were long overdue, and this crate hasn't seen any love in years. It's time to change that!