### PR TITLE
Convert to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "renderdoc"
 version = "0.7.1"
+edition = "2018"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "RenderDoc application bindings for Rust"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,21 +20,6 @@
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 compile_error!("RenderDoc does not support this platform.");
 
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate float_cmp;
-extern crate libloading;
-extern crate once_cell;
-extern crate renderdoc_sys;
-
-#[cfg(feature = "glutin")]
-extern crate glutin;
-#[cfg(target_os = "windows")]
-extern crate winapi;
-#[cfg(target_os = "windows")]
-extern crate wio;
-
 pub use self::error::Error;
 pub use self::handles::{DevicePointer, WindowHandle};
 pub use self::renderdoc::RenderDoc;

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -7,10 +7,12 @@ use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::ptr;
 
-use error::Error;
-use handles::{DevicePointer, WindowHandle};
-use settings::{CaptureOption, InputButton, OverlayBits};
-use version::{Entry, HasPrevious, Version, V100, V110, V111, V112, V120, V130, V140};
+use float_cmp::approx_eq;
+
+use crate::error::Error;
+use crate::handles::{DevicePointer, WindowHandle};
+use crate::settings::{CaptureOption, InputButton, OverlayBits};
+use crate::version::{Entry, HasPrevious, Version, V100, V110, V111, V112, V120, V130, V140};
 
 /// An instance of the RenderDoc API with baseline version `V`.
 #[repr(C)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,6 +2,7 @@
 
 use std::u32;
 
+use bitflags::bitflags;
 #[cfg(feature = "glutin")]
 use glutin::VirtualKeyCode;
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -7,7 +7,7 @@ use libloading::{Library, Symbol};
 use once_cell::sync::OnceCell;
 use renderdoc_sys::RENDERDOC_API_1_4_0;
 
-use error::Error;
+use crate::error::Error;
 
 static RD_LIB: OnceCell<Library> = OnceCell::new();
 


### PR DESCRIPTION
### Changed

* Convert to Rust 2018 edition. Given that we have finally found a reason to increase the minimum supported version to 1.40.0 with #78, and we can't support older compilers anyway, this should be perfectly safe to do.