### PR TITLE
Fix some minor documentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ examine the graphics pipeline state, and potentially identify nasty graphics
 bugs.
 
 These bindings require that RenderDoc be installed on the target machine, with
-either `renderdoc.dll` or `librenderdoc.so` visible from your`PATH`.
+either `renderdoc.dll` or `librenderdoc.so` visible from your `$PATH`.
 
 For more details on how to use this API to integrate your game or renderer with
 the RenderDoc profiler, consult the [in-application API][in-app] documentation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! and potentially identify nasty graphics bugs.
 //!
 //! These bindings require that RenderDoc be installed on the target machine, with either
-//! `renderdoc.dll` or `librenderdoc.so` visible from your`PATH`.
+//! `renderdoc.dll` or `librenderdoc.so` visible from your `$PATH`.
 //!
 //! For more details on how to use this API to integrate your game or renderer with the RenderDoc
 //! profiler, consult the upstream [in-application API][in-app] documentation.

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -432,7 +432,7 @@ impl RenderDoc<V100> {
     /// For example, you can specify `null(), null()` for the device to capture on if you have only
     /// one device and only one or zero windows, and RenderDoc will capture from that device.
     ///
-    /// This function must be paired with a matching `end_frame_capture()` to complete.
+    /// This function must be paired with a matching `start_frame_capture()` to succeed.
     ///
     /// ```rust,no_run
     /// # use renderdoc::{Error, RenderDoc, V100};

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -192,9 +192,8 @@ impl RenderDoc<V100> {
     /// Removes RenderDoc's injected crash handler from the current process.
     ///
     /// This allows you to provide your own global crash handler with which to handle exceptions,
-    /// if you so desire.
-    ///
-    /// After the crash handler has been removed, subsequent calls to this method will do nothing.
+    /// if you so desire. After the crash handler has been removed, subsequent calls to this method
+    /// will do nothing.
     pub fn unload_crash_handler(&mut self) {
         unsafe {
             ((*self.0).UnloadCrashHandler.unwrap())();


### PR DESCRIPTION
### Fixed

* Fix copy-paste documentation error for `end_frame_capture()`.
* Fix formatting for `unload_crash_handler()` docs.
* Fix subtle spacing issue around `$PATH` in docs.