### PR TITLE
Fix semantics of shutdown(), remove remove_hooks() for now

### DIFF
--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -36,6 +36,26 @@ impl<V: Version> RenderDoc<V> {
     pub unsafe fn raw_api(&self) -> *mut Entry {
         self.0
     }
+
+    /// Attempts to shut down RenderDoc.
+    ///
+    /// # Safety
+    ///
+    /// Note that this will work correctly if done _immediately_ after the dynamic library is
+    /// loaded, before any API work happens. At that point, RenderDoc will remove its injected
+    /// hooks and shut down. Behavior is undefined if this is called after any API functions have
+    /// been called.
+    ///
+    /// # Compatibility
+    ///
+    /// This process is only possible on Windows, and even then it is not well defined so may not
+    /// be possible in all circumstances. This function is provided at your own risk.
+    // FIXME: Need to move this to `RenderDoc<V100>` and add `remove_hooks()` to `RenderDoc<V141>`.
+    // This is currently impossible to do until https://github.com/rust-lang/rfcs/issues/997 is
+    // resolved, since `Deref` nor `DerefMut` is sufficient for the task.
+    pub unsafe fn shutdown(self) {
+        ((*self.0).__bindgen_anon_1.Shutdown.unwrap())();
+    }
 }
 
 impl<V: HasPrevious> RenderDoc<V> {
@@ -89,23 +109,6 @@ impl<V: Version> Debug for RenderDoc<V> {
 }
 
 impl RenderDoc<V100> {
-    /// Attempts to shut down RenderDoc.
-    ///
-    /// # Safety
-    ///
-    /// Note that this will work correctly if done _immediately_ after the dynamic library is
-    /// loaded, before any API work happens. At that point, RenderDoc will remove its injected
-    /// hooks and shut down. Behavior is undefined if this is called after any API functions have
-    /// been called.
-    ///
-    /// # Compatibility
-    ///
-    /// This process is only possible on Windows, and even then it is not well defined so may not
-    /// be possible in all circumstances. This function is provided at your own risk.
-    pub unsafe fn shutdown(self) {
-        ((*self.0).__bindgen_anon_1.Shutdown.unwrap())();
-    }
-
     /// Returns the major, minor, and patch version numbers of the RenderDoc API currently in use.
     ///
     /// Note that RenderDoc will usually provide a higher API version than the one requested by
@@ -655,31 +658,6 @@ impl RenderDoc<V140> {
     {
         let DevicePointer(dev) = dev.into();
         unsafe { ((*self.0).DiscardFrameCapture.unwrap())(dev as *mut _, win as *mut _) == 1 }
-    }
-}
-
-impl RenderDoc<V141> {
-    /// Attempts to shut down RenderDoc.
-    ///
-    /// # Safety
-    ///
-    /// Note that this will work correctly if done _immediately_ after the dynamic library is
-    /// loaded, before any API work happens. At that point, RenderDoc will remove its injected
-    /// hooks and shut down. Behavior is undefined if this is called after any API functions have
-    /// been called.
-    ///
-    /// # Compatibility
-    ///
-    /// This process is only possible on Windows, and even then it is not well defined so may not
-    /// be possible in all circumstances. This function is provided at your own risk.
-    pub unsafe fn remove_hooks(self) {
-        ((*self.0).__bindgen_anon_1.RemoveHooks.unwrap())();
-    }
-
-    /// Attempts to shut down RenderDoc.
-    #[deprecated(since = "1.4.1", note = "renamed to `remove_hooks`")]
-    pub unsafe fn shutdown(self) {
-        ((*self.0).__bindgen_anon_1.Shutdown.unwrap())();
     }
 }
 


### PR DESCRIPTION
### Changed

* Restore `shutdown()` method to the `RenderDoc<V: Version>` impl block.

### Removed

* Remove `remove_hooks()` and `RenderDoc<V141>` impl block for now.

The previous changes from #91, moving `shutdown()` to the specific `RenderDoc<V100>` impl block and the addition of `remove_hooks()` to `RenderDoc<V141>`, won't actually work as intended in practice.

This is because the existing `Deref` and `DerefMut` implementations are not sufficient for either method to work properly. This would require the introduction of a `DerefMove` trait in the standard library to work (see https://github.com/rust-lang/rfcs/issues/997 for details).