### PR TITLE
Upgrade to glutin 0.24 and turn integration off by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libloading = "0.6"
 once_cell = "1.0"
 renderdoc-sys = { version = "0.7", path = "./renderdoc-sys" }
 
-glutin = { version = "0.21", optional = true }
+glutin = { version = "0.24", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["d3d12","d3d11"] }
@@ -31,7 +31,7 @@ wio = "0.2"
 [dev-dependencies]
 gfx = "0.18.1"
 gfx_window_glutin = "0.31"
-glutin = "0.21"
+glutin-021 = { version = "0.21", package = "glutin" }
 
 [workspace]
 members = [".", "renderdoc-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ keywords = ["graphics", "profile", "renderdoc", "trace"]
 [badges]
 circle-ci = { repository = "ebkalderon/renderdoc-rs" }
 
-[features]
-default = ["glutin"]
-
 [dependencies]
 bitflags = "1.0"
 float-cmp = "0.8"

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -15,13 +15,10 @@
 
 #[macro_use]
 extern crate gfx;
-extern crate gfx_window_glutin;
-extern crate glutin;
-extern crate renderdoc;
 
 use gfx::traits::FactoryExt;
 use gfx::Device;
-use glutin::GlProfile;
+use glutin_021::GlProfile;
 use renderdoc::{RenderDoc, V110};
 
 pub type ColorFormat = gfx::format::Rgba8;
@@ -59,11 +56,11 @@ const CLEAR_COLOR: [f32; 4] = [0.1, 0.2, 0.3, 1.0];
 pub fn main() {
     let mut rd: RenderDoc<V110> = RenderDoc::new().unwrap();
 
-    let mut events_loop = glutin::EventsLoop::new();
-    let window_config = glutin::WindowBuilder::new()
+    let mut events_loop = glutin_021::EventsLoop::new();
+    let window_config = glutin_021::WindowBuilder::new()
         .with_title("Triangle example".to_string())
         .with_dimensions((1024, 768).into());
-    let context = glutin::ContextBuilder::new()
+    let context = glutin_021::ContextBuilder::new()
         .with_vsync(true)
         .with_gl_profile(GlProfile::Core);
 
@@ -85,22 +82,21 @@ pub fn main() {
         out: main_color,
     };
 
-    rd.set_active_window(window.context(), std::ptr::null());
-    rd.set_focus_toggle_keys(&[glutin::VirtualKeyCode::F]);
-    rd.set_capture_keys(&[glutin::VirtualKeyCode::C]);
+    rd.set_focus_toggle_keys(&[renderdoc::InputButton::F]);
+    rd.set_capture_keys(&[renderdoc::InputButton::C]);
     rd.set_capture_option_u32(renderdoc::CaptureOption::AllowVSync, 1);
     rd.set_capture_option_u32(renderdoc::CaptureOption::ApiValidation, 1);
 
     let mut running = true;
     while running {
         events_loop.poll_events(|event| {
-            if let glutin::Event::WindowEvent { event, .. } = event {
+            if let glutin_021::Event::WindowEvent { event, .. } = event {
                 match event {
-                    glutin::WindowEvent::KeyboardInput {
+                    glutin_021::WindowEvent::KeyboardInput {
                         input:
-                            glutin::KeyboardInput {
-                                virtual_keycode: Some(glutin::VirtualKeyCode::R),
-                                state: glutin::ElementState::Pressed,
+                            glutin_021::KeyboardInput {
+                                virtual_keycode: Some(glutin_021::VirtualKeyCode::R),
+                                state: glutin_021::ElementState::Pressed,
                                 ..
                             },
                         ..
@@ -108,16 +104,16 @@ pub fn main() {
                         Ok(pid) => println!("Launched replay UI ({}).", pid),
                         Err(err) => eprintln!("{:?}", err),
                     },
-                    glutin::WindowEvent::KeyboardInput {
+                    glutin_021::WindowEvent::KeyboardInput {
                         input:
-                            glutin::KeyboardInput {
-                                virtual_keycode: Some(glutin::VirtualKeyCode::Escape),
+                            glutin_021::KeyboardInput {
+                                virtual_keycode: Some(glutin_021::VirtualKeyCode::Escape),
                                 ..
                             },
                         ..
                     }
-                    | glutin::WindowEvent::CloseRequested => running = false,
-                    glutin::WindowEvent::Resized(logical_size) => {
+                    | glutin_021::WindowEvent::CloseRequested => running = false,
+                    glutin_021::WindowEvent::Resized(logical_size) => {
                         let dpi_factor = window.window().get_hidpi_factor();
                         window.resize(logical_size.to_physical(dpi_factor));
                         gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);

--- a/src/handles.rs
+++ b/src/handles.rs
@@ -3,7 +3,7 @@
 use std::os::raw::c_void;
 
 #[cfg(feature = "glutin")]
-use glutin::os::ContextTraitExt;
+use glutin::platform::ContextTraitExt;
 #[cfg(windows)]
 use wio::com::ComPtr;
 
@@ -69,7 +69,7 @@ impl<'a, T: glutin::ContextCurrentState> From<&'a glutin::Context<T>> for Device
     fn from(ctx: &'a glutin::Context<T>) -> Self {
         #[cfg(unix)]
         unsafe {
-            use glutin::os::unix::RawHandle;
+            use glutin::platform::unix::RawHandle;
             match ctx.raw_handle() {
                 RawHandle::Glx(glx) => DevicePointer::from(glx),
                 _ => panic!("RenderDoc only supports GLX contexts on Unix!"),
@@ -78,7 +78,7 @@ impl<'a, T: glutin::ContextCurrentState> From<&'a glutin::Context<T>> for Device
 
         #[cfg(windows)]
         unsafe {
-            use glutin::os::windows::RawHandle;
+            use glutin::platform::windows::RawHandle;
             match ctx.raw_handle() {
                 RawHandle::Wgl(wgl) => DevicePointer::from(wgl),
                 _ => panic!("RenderDoc only supports WGL contexts on Windows!"),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,7 +4,7 @@ use std::u32;
 
 use bitflags::bitflags;
 #[cfg(feature = "glutin")]
-use glutin::VirtualKeyCode;
+use glutin::event::VirtualKeyCode;
 
 /// RenderDoc capture options.
 #[repr(u32)]
@@ -159,8 +159,8 @@ pub enum InputButton {
 }
 
 #[cfg(feature = "glutin")]
-impl From<glutin::VirtualKeyCode> for InputButton {
-    fn from(code: glutin::VirtualKeyCode) -> InputButton {
+impl From<glutin::event::VirtualKeyCode> for InputButton {
+    fn from(code: glutin::event::VirtualKeyCode) -> InputButton {
         match code {
             VirtualKeyCode::Key1 => InputButton::Key1,
             VirtualKeyCode::Key2 => InputButton::Key2,


### PR DESCRIPTION
### Changed

* Upgrade to `glutin` 0.24.
* Disable `glutin` integration by default.

Considering that `glutin` isn't necessary for `wgpu-rs` and isn't tightly integrated like it used to be with `gfx` pre-`ll`, this integration is turned off by default to avoid dragging in unnecessary dependencies.