### PR TITLE
Prepare release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.9.0] - 2020-05-17
+
+### Added
+
+* Implement preliminary support for API version 1.4.1 (see #93).
+
+### Changed
+
+* Bump `glutin` dependency to 0.24, disable integration by default (PR #94).
+
 ## [0.8.1] - 2020-05-01
 
 ### Fixed
@@ -177,7 +187,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Type-safe version requests and downgrading.
 * Convenient conversions for `winit::VirtualKeyCode` into RenderDoc `InputButton`.
 
-[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.7.0...v0.7.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2018"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "RenderDoc application bindings for Rust"


### PR DESCRIPTION
### Changed

* Update `CHANGELOG.md`.
* Bump `renderdoc` crate version to 0.9.0.