### PR TITLE
Enable all features when building for Docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 categories = ["rendering"]
 keywords = ["graphics", "profile", "renderdoc", "trace"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [badges]
 circle-ci = { repository = "ebkalderon/renderdoc-rs" }
 


### PR DESCRIPTION
### Changed

* Enable all features when building for Docs.rs. This is done in order to showcase the `glutin` integration, if the feature is enabled by the user.