### PR TITLE
Remove extern crate from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ the RenderDoc profiler, consult the [in-application API][in-app] documentation.
 ## Example
 
 ```rust
-extern crate renderdoc;
-
 use renderdoc::{RenderDoc, V100, V110};
 
 fn main() {


### PR DESCRIPTION
### Changed

* Remove `extern crate` from `README` example.

Since the 2018 edition has been mainstream for quite a while, we should update the `README.md` to reflect that.