### PR TITLE
Exclude extra files and dirs from crates

### DIFF
--- a/renderdoc-sys/Cargo.toml
+++ b/renderdoc-sys/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/ebkalderon/renderdoc-rs"
 documentation = "https://docs.rs/renderdoc-sys/"
 readme = "README.md"
 keywords = ["ffi", "renderdoc"]
+exclude = ["/vendor"]
 
 [badges]
 circle-ci = { repository = "ebkalderon/renderdoc-rs" }


### PR DESCRIPTION
### Changed

* Exclude the `vendor` subdirectory from the `renderdoc-sys` crate.