### PR TITLE
Fix get_capture() example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ fn main() {
 
     // Query the details of an existing capture like this.
     match rd.get_capture(0) {
-        Some(cap) => println!("ID: 0, Path: {}, Timestamp: {}", cap.0, cap.1),
+        Some(cap) => println!("ID: 0, Path: {}, Timestamp: {:?}", cap.0, cap.1),
         None => println!("No capture found with ID of 0!"),
     }
 


### PR DESCRIPTION
### Fixed

* Fix example in `README.md` by switching to `{:?}` format string.

Since `get_capture()` was changed in #86 to return an `std::time::SystemTime` representing the timestamp instead of a plain `u64`, the example code in the README no longer compiles due to this type not implementing `Display`.