### PR TITLE
Prepare release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.9.1] - 2020-08-05
+
+### Changed
+
+* Allow global synchronized access to RenderDoc (see #79).
+* Exclude `vendor` subdirectory from `renderdoc-sys` crate.
+* Enable all crate features when generating docs for docs.rs.
+
+### Fixed
+
+* Expose `V141` version selector.
+
 ## [0.9.0] - 2020-05-17
 
 ### Added
@@ -187,7 +199,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Type-safe version requests and downgrading.
 * Convenient conversions for `winit::VirtualKeyCode` into RenderDoc `InputButton`.
 
-[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.9.1...HEAD
+[0.9.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.7.1...v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2018"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "RenderDoc application bindings for Rust"

--- a/renderdoc-sys/Cargo.toml
+++ b/renderdoc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc-sys"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Raw FFI bindings to the RenderDoc API"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,9 @@ pub use self::error::Error;
 pub use self::handles::{DevicePointer, WindowHandle};
 pub use self::renderdoc::RenderDoc;
 pub use self::settings::{CaptureOption, InputButton, OverlayBits};
-pub use self::version::{Entry, HasPrevious, Version, V100, V110, V111, V112, V120, V130, V140};
+pub use self::version::{
+    Entry, HasPrevious, Version, V100, V110, V111, V112, V120, V130, V140, V141,
+};
 
 use std::os::raw::c_ulonglong;
 

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -99,17 +99,6 @@ impl<V: HasPrevious> DerefMut for RenderDoc<V> {
     }
 }
 
-impl<V: Version> Debug for RenderDoc<V> {
-    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
-        fmt.debug_tuple(stringify!(RenderDoc))
-            .field(&self.0)
-            .field(&V::VERSION)
-            .finish()
-    }
-}
-
-unsafe impl<V> Send for RenderDoc<V> {}
-
 impl RenderDoc<V100> {
     /// Returns the major, minor, and patch version numbers of the RenderDoc API currently in use.
     ///
@@ -662,6 +651,17 @@ impl RenderDoc<V140> {
         unsafe { ((*self.0).DiscardFrameCapture.unwrap())(dev as *mut _, win as *mut _) == 1 }
     }
 }
+
+impl<V: Version> Debug for RenderDoc<V> {
+    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
+        fmt.debug_tuple(stringify!(RenderDoc))
+            .field(&self.0)
+            .field(&V::VERSION)
+            .finish()
+    }
+}
+
+unsafe impl<V> Send for RenderDoc<V> {}
 
 /// Generates `From` implementations that permit downgrading of API versions.
 ///

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -83,18 +83,18 @@ impl<V: HasPrevious> Deref for RenderDoc<V> {
     type Target = RenderDoc<V::Previous>;
 
     fn deref(&self) -> &Self::Target {
-        // NOTE: This transmutation is actually safe because the underlying entry point exposed by
-        // the RenderDoc API is the exact same structure. This call only serves to recursively
-        // expose the methods in a statically guaranteed and backwards-compatible way.
+        // NOTE: This transmutation is safe because the entry point type and layout does not change
+        // between API versions. This call only serves as type-level magic to expose the inherent
+        // methods in a backwards-compatible way.
         unsafe { &*(self as *const RenderDoc<V> as *const RenderDoc<<V as HasPrevious>::Previous>) }
     }
 }
 
 impl<V: HasPrevious> DerefMut for RenderDoc<V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        // NOTE: This transmutation is actually safe because the underlying entry point exposed by
-        // the RenderDoc API is the exact same structure. This call only serves to recursively
-        // expose the methods in a statically guaranteed and backwards-compatible way.
+        // NOTE: This transmutation is safe because the entry point type and layout does not change
+        // between API versions. This call only serves as type-level magic to expose the inherent
+        // methods in a backwards-compatible way.
         unsafe { &mut *(self as *mut RenderDoc<V> as *mut RenderDoc<<V as HasPrevious>::Previous>) }
     }
 }

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -108,6 +108,8 @@ impl<V: Version> Debug for RenderDoc<V> {
     }
 }
 
+unsafe impl<V> Send for RenderDoc<V> {}
+
 impl RenderDoc<V100> {
     /// Returns the major, minor, and patch version numbers of the RenderDoc API currently in use.
     ///


### PR DESCRIPTION
### Changed

* Allow global synchronized access (`Send` + `!Sync`) to RenderDoc (see #79).
* Minor stylistic improvements.
* Update `CHANGELOG.md`.
* Bump `renderdoc-sys` crate to 0.7.1.
* Bump `renderdoc` crate to 0.9.0.

### Fixed

* Expose `V141` version selector, which should have been done in `renderdoc` 0.9.0.
