### PR TITLE
Clarify wording of README license disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Working examples are available in the `examples` directory.
 ## License
 
 `renderdoc-rs` is free and open source software distributed under the terms of
-both the [MIT](LICENSE-MIT) and the [Apache 2.0](LICENSE-APACHE) licenses.
+either the [MIT](LICENSE-MIT) or the [Apache 2.0](LICENSE-APACHE) license, at
+your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be


### PR DESCRIPTION
### Fixed

* Crate is dual-licensed under _either_ the MIT or Apache 2.0 licenses, at the user's option, not both simultaneously.