### PR TITLE
Prepare release 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.1] - 2021-02-10
+
+### Changed
+
+* Bump `libloading` dependency to 0.7.
+
 ## [0.10.0] - 2020-12-17
 
 ### Changed
@@ -205,7 +211,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Type-safe version requests and downgrading.
 * Convenient conversions for `winit::VirtualKeyCode` into RenderDoc `InputButton`.
 
-[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.8.1...v0.9.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2018"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "RenderDoc application bindings for Rust"


### PR DESCRIPTION
### Changed

* Update `CHANGELOG.md`.
* Bump `renderdoc` crate version to 0.10.1.