### PR TITLE
Switch to Rust 1.48.0 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ebkalderon/renderdoc-rs-circleci:1.40.0
+      - image: ebkalderon/renderdoc-rs-circleci:1.48.0
 
     environment:
       TZ: "/usr/share/zoneinfo/Asia/Singapore"


### PR DESCRIPTION
### Changed

* Switch to Rust 1.48.0 in CircleCI to make #110 pass in CI.

Related to https://github.com/ebkalderon/renderdoc-rs-circleci-dockerfile/pull/6.