### PR TITLE
Fix broken CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             rustup run nightly cargo --version --verbose
             rustup run nightly cargo build --all
       - save_cache:
-          key: project-cache
+          key: project-cache-1
           paths:
             - "~/.cargo"
             - "./target"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: ebkalderon/renderdoc-rs-circleci:1.48.0
 
     environment:
-      TZ: "/usr/share/zoneinfo/Asia/Singapore"
+      TZ: "/usr/share/zoneinfo/America/New_York"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ebkalderon/renderdoc-rs-circleci:1.48.0
+      - image: ebkalderon/renderdoc-rs-circleci:1.54.0
 
     environment:
       TZ: "/usr/share/zoneinfo/America/New_York"


### PR DESCRIPTION
### Changed

* Update CircleCI timezone from `Asia/Singapore` to `America/New_York`.

### Fixed

* Clear CircleCI project cache.
* Use new [ebkalderon/renderdoc-rs-circleci-dockerfile](https://github.com/ebkalderon/renderdoc-rs-circleci-dockerfile) image with Rust 1.51.0 to fix breaking builds.