### PR TITLE
Fix triangle example by adding missing dev-dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
       with:
         command: test
         args: --workspace --all-features
+    - name: Check examples
+      continue-on-error: ${{ matrix.continue-on-error || false }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --examples
 
   cargo-audit:
     name: cargo audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ wio = "0.2"
 pollster = "0.2"
 wgpu = "0.15"
 wgpu-subscriber = "0.1.0"
+winit = "0.27"
 
 [workspace]
 members = [".", "renderdoc-sys"]


### PR DESCRIPTION
### Fixed

* Re-add missing `winit` 0.27 dev-dependency to fix triangle example.
* Check all examples compile in GitHub Actions, so this does not slip through again.