### PR TITLE
Fix undefined behavior and crash in `get_capture`

### DIFF
--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -323,12 +323,7 @@ impl RenderDoc<V100> {
         unsafe {
             if ((*self.0).GetCapture.unwrap())(index, path.as_mut_ptr(), &mut len, &mut time) == 1 {
                 let capture_time = time::UNIX_EPOCH + Duration::from_secs(time);
-                let path = {
-                    let raw_path = CString::from_raw(path.as_mut_ptr());
-                    let mut path = raw_path.into_string().unwrap();
-                    path.shrink_to_fit();
-                    path
-                };
+                let path = CStr::from_ptr(path.as_ptr()).to_str().unwrap();
 
                 Some((path.into(), capture_time))
             } else {

--- a/src/renderdoc.rs
+++ b/src/renderdoc.rs
@@ -309,7 +309,14 @@ impl RenderDoc<V100> {
     /// # }
     /// ```
     pub fn get_capture(&self, index: u32) -> Option<(PathBuf, SystemTime)> {
-        let mut len = self.get_log_file_path_template().as_os_str().len() as u32 + 128;
+        let mut len = 0;
+        if unsafe {
+            (*self.0).GetCapture.unwrap()(index, ptr::null_mut(), &mut len, ptr::null_mut())
+        } == 0
+        {
+            return None;
+        };
+
         let mut path = Vec::with_capacity(len as usize);
         let mut time = 0u64;
 


### PR DESCRIPTION
There are two issues in the `get_capture` function
- it assumes the file name will fit into 128 characters and overruns the allocated buffer otherwise
- it's using [`CString::from_raw`](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.from_raw) incorrectly (see the safety section in the rust docs)

This PR fixes both.

The second issue was causing crashes with `STATUS_HEAP_CORRUPTION` for me because it did some funky things when trying to de-allocate the `CString` (I think it double-frees and the second free also uses the wrong layout; didn't look into it more).

I know you're currently rewriting most of the library but I wanted to share this anyway in case anyone else runs into the same crash.