### PR TITLE
Prepare release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.12.1] - 2024-03-01
+
 ### Added
 
 * Add `eRENDERDOC_Option_SoftMemoryLimit` symbol to `renderdoc-sys` (PR #151).
+
+### Changed
+
+* Update `renderdoc-sys` dependency to 1.1.0 (PR #152).
 
 ## [0.12.0] - 2024-03-01
 
@@ -238,7 +244,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Type-safe version requests and downgrading.
 * Convenient conversions for `winit::VirtualKeyCode` into RenderDoc `InputButton`.
 
-[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/ebkalderon/renderdoc-rs/compare/v0.10.0...v0.10.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2018"
 resolver = "2"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
@@ -30,7 +30,7 @@ bitflags = "2.0"
 float-cmp = "0.9"
 libloading = "0.8"
 once_cell = "1.0"
-renderdoc-sys = { version = "1.0.0", path = "./renderdoc-sys" }
+renderdoc-sys = { version = "1.1.0", path = "./renderdoc-sys" }
 
 glutin = { version = "0.30", optional = true }
 winit = { version = "0.28", optional = true }

--- a/renderdoc-sys/Cargo.toml
+++ b/renderdoc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renderdoc-sys"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Low-level bindings to the RenderDoc API"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed

* Bump `renderdoc-sys` crate version to 1.1.0.
* Bump `renderdoc` crate version to 0.12.1.
  * Because the changes in `renderdoc-sys` between 1.0.0 and 1.1.0 are entirely additive and do not impact the outward-facing API of the `renderdoc` crate at all, it should be safe to bump the patch version number here instead of the minor version.
* Update `CHANGELOG.md`